### PR TITLE
Docker: reverse proxy bugfixes 

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,7 +19,11 @@ RUN curl -s -L -S -k https://www.factorio.com/get-download/$FACTORIO_VERSION/hea
     rm /tmp/factorio_$FACTORIO_VERSION.tar.gz && \
     curl -s -L -S -k https://github.com/MajorMJR/factorio-server-manager/releases/download/$MANAGER_VERSION/factorio-server-manager-linux-x64.zip --cacert /opt/github.pem -o /tmp/factorio-server-manager-linux-x64_$MANAGER_VERSION.zip && \
     unzip -qq /tmp/factorio-server-manager-linux-x64_$MANAGER_VERSION.zip && \
-    rm /tmp/factorio-server-manager-linux-x64_$MANAGER_VERSION.zip
+    rm /tmp/factorio-server-manager-linux-x64_$MANAGER_VERSION.zip && \
+    rm -r /var/lib/nginx && \
+    mkdir -p /var/lib/nginx/tmp && \
+    chown nginx:root /var/lib/nginx
+
 EXPOSE 80/tcp 443/tcp 34190-34200/udp
 
 ENTRYPOINT ["/opt/init.sh"]

--- a/docker/init.sh
+++ b/docker/init.sh
@@ -28,6 +28,7 @@ if [ ! -f /security/passwords.conf ]; then
 	openssl passwd -apr1 $ADMIN_PASSWORD >> /security/passwords.conf
 fi
 
+chown nginx:root /var/lib/nginx/tmp/
 
 nohup nginx &
 /opt/factorio-server/factorio-server-manager -dir /opt/factorio

--- a/docker/init.sh
+++ b/docker/init.sh
@@ -28,7 +28,5 @@ if [ ! -f /security/passwords.conf ]; then
 	openssl passwd -apr1 $ADMIN_PASSWORD >> /security/passwords.conf
 fi
 
-chown nginx:root /var/lib/nginx/tmp/
-
 nohup nginx &
 /opt/factorio-server/factorio-server-manager -dir /opt/factorio

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -21,7 +21,7 @@ http {
     #tcp_nopush     on;
 
     keepalive_timeout  65;
-
+    client_max_body_size 100m;
     #gzip  on;
 
     server {

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -58,6 +58,7 @@ http {
 
         location / {
                 root /opt/factorio-server/app;
+		try_files $uri /index.html;
         }
 
     }


### PR DESCRIPTION
Fixed: 404 on refresh of suppages ( #18 )
Fixed: errors during download/upload of big files ( #14 )

Dockerfile:22-26 might be confusing, but this is the only way to avoid a docker bug I encountered.