### PR TITLE
Default to the latest factorio server

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,7 @@ FROM frolvlad/alpine-glibc
 
 MAINTAINER Jannik Kolodziej <docker@jkolodziej.de>
 
-ENV FACTORIO_VERSION=0.12.33 \
+ENV FACTORIO_VERSION=latest \
     MANAGER_VERSION=0.4.1 \
     ADMIN_PASSWORD=
 


### PR DESCRIPTION
The container fails to build because 0.12.33 returns an internal server error. Use the latest server build by default.