### PR TITLE
Move login to the api router.

### DIFF
--- a/src/routes.go
+++ b/src/routes.go
@@ -29,7 +29,7 @@ func NewRouter() *mux.Router {
 			Handler(AuthorizeHandler(route.HandlerFunc))
 	}
 
-    // The login handler does not check for authentication.
+	// The login handler does not check for authentication.
 	s.Path("/login").
 		Methods("POST").
 		Name("LoginUser").

--- a/src/routes.go
+++ b/src/routes.go
@@ -27,11 +27,11 @@ func NewRouter() *mux.Router {
 		apiRoute := s.Methods(route.Method).
 			Path(route.Pattern).
 			Name(route.Name)
-        if route.Middleware != nil {
-		    apiRoute.Handler(route.Middleware(route.HandlerFunc))
-        } else {
-		    apiRoute.Handler(route.HandlerFunc)
-        }
+		if route.Middleware != nil {
+			apiRoute.Handler(route.Middleware(route.HandlerFunc))
+		} else {
+			apiRoute.Handler(route.HandlerFunc)
+		}
 	}
 
 	// Serves the frontend application from the app directory

--- a/src/routes.go
+++ b/src/routes.go
@@ -26,7 +26,7 @@ func NewRouter() *mux.Router {
 		s.Methods(route.Method).
 			Path(route.Pattern).
 			Name(route.Name).
-			Handler(CheckAuth(route.HandlerFunc))
+			Handler(AuthorizeHandler(route.HandlerFunc))
 	}
 
     // The login handler does not check for authentication.
@@ -45,27 +45,27 @@ func NewRouter() *mux.Router {
 	r.Path("/settings").
 		Methods("GET").
 		Name("Settings").
-		Handler(CheckAuth(http.StripPrefix("/settings", http.FileServer(http.Dir("./app/")))))
+		Handler(AuthorizeHandler(http.StripPrefix("/settings", http.FileServer(http.Dir("./app/")))))
 	r.Path("/mods").
 		Methods("GET").
 		Name("Mods").
-		Handler(CheckAuth(http.StripPrefix("/mods", http.FileServer(http.Dir("./app/")))))
+		Handler(AuthorizeHandler(http.StripPrefix("/mods", http.FileServer(http.Dir("./app/")))))
 	r.Path("/saves").
 		Methods("GET").
 		Name("Saves").
-		Handler(CheckAuth(http.StripPrefix("/saves", http.FileServer(http.Dir("./app/")))))
+		Handler(AuthorizeHandler(http.StripPrefix("/saves", http.FileServer(http.Dir("./app/")))))
 	r.Path("/logs").
 		Methods("GET").
 		Name("Logs").
-		Handler(CheckAuth(http.StripPrefix("/logs", http.FileServer(http.Dir("./app/")))))
+		Handler(AuthorizeHandler(http.StripPrefix("/logs", http.FileServer(http.Dir("./app/")))))
 	r.Path("/config").
 		Methods("GET").
 		Name("Config").
-		Handler(CheckAuth(http.StripPrefix("/config", http.FileServer(http.Dir("./app/")))))
+		Handler(AuthorizeHandler(http.StripPrefix("/config", http.FileServer(http.Dir("./app/")))))
 	r.Path("/server").
 		Methods("GET").
 		Name("Server").
-		Handler(CheckAuth(http.StripPrefix("/server", http.FileServer(http.Dir("./app/")))))
+		Handler(AuthorizeHandler(http.StripPrefix("/server", http.FileServer(http.Dir("./app/")))))
 	r.PathPrefix("/").
 		Methods("GET").
 		Name("Index").
@@ -76,7 +76,7 @@ func NewRouter() *mux.Router {
 
 // Middleware returns a http.HandlerFunc which authenticates the users request
 // Redirects user to login page if no session is found
-func CheckAuth(h http.Handler) http.Handler {
+func AuthorizeHandler(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if err := Auth.aaa.Authorize(w, r, true); err != nil {
 			log.Printf("Unauthenticated request %s %s %s", r.Method, r.Host, r.RequestURI)

--- a/src/routes.go
+++ b/src/routes.go
@@ -12,7 +12,6 @@ type Route struct {
 	Method      string
 	Pattern     string
 	HandlerFunc http.HandlerFunc
-	Middleware  func(http.Handler) http.Handler
 }
 
 type Routes []Route
@@ -24,15 +23,17 @@ func NewRouter() *mux.Router {
 	// Serves all JSON REST handlers prefixed with /api
 	s := r.PathPrefix("/api").Subrouter()
 	for _, route := range apiRoutes {
-		apiRoute := s.Methods(route.Method).
+		s.Methods(route.Method).
 			Path(route.Pattern).
-			Name(route.Name)
-		if route.Middleware != nil {
-			apiRoute.Handler(route.Middleware(route.HandlerFunc))
-		} else {
-			apiRoute.Handler(route.HandlerFunc)
-		}
+			Name(route.Name).
+			Handler(CheckAuth(route.HandlerFunc))
 	}
+
+    // The login handler does not check for authentication.
+	s.Path("/login").
+		Methods("POST").
+		Name("LoginUser").
+		HandlerFunc(LoginUser)
 
 	// Serves the frontend application from the app directory
 	// Uses basic file server to serve index.html and Javascript application
@@ -94,162 +95,130 @@ var apiRoutes = Routes{
 		"GET",
 		"/mods/list/installed",
 		ListInstalledMods,
-        CheckAuth,
 	}, {
 		"ListMods",
 		"GET",
 		"/mods/list",
 		ListMods,
-        CheckAuth,
 	}, {
 		"ToggleMod",
 		"GET",
 		"/mods/toggle/{mod}",
 		ToggleMod,
-        CheckAuth,
 	}, {
 		"UploadMod",
 		"POST",
 		"/mods/upload",
 		UploadMod,
-        CheckAuth,
 	}, {
 		"RemoveMod",
 		"GET",
 		"/mods/rm/{mod}",
 		RemoveMod,
-        CheckAuth,
 	}, {
 		"DownloadMod",
 		"GET",
 		"/mods/dl/{mod}",
 		DownloadMod,
-        CheckAuth,
 	}, {
 		"ListSaves",
 		"GET",
 		"/saves/list",
 		ListSaves,
-        CheckAuth,
 	}, {
 		"DlSave",
 		"GET",
 		"/saves/dl/{save}",
 		DLSave,
-        CheckAuth,
 	}, {
 		"UploadSave",
 		"POST",
 		"/saves/upload",
 		UploadSave,
-        CheckAuth,
 	}, {
 		"RemoveSave",
 		"GET",
 		"/saves/rm/{save}",
 		RemoveSave,
-        CheckAuth,
 	}, {
 		"CreateSave",
 		"GET",
 		"/saves/create/{save}",
 		CreateSaveHandler,
-        CheckAuth,
 	}, {
 		"LogTail",
 		"GET",
 		"/log/tail",
 		LogTail,
-        CheckAuth,
 	}, {
 		"LoadConfig",
 		"GET",
 		"/config",
 		LoadConfig,
-        CheckAuth,
 	}, {
 		"StartServer",
 		"GET",
 		"/server/start",
 		StartServer,
-        CheckAuth,
 	}, {
 		"StartServer",
 		"POST",
 		"/server/start",
 		StartServer,
-        CheckAuth,
 	}, {
 		"StopServer",
 		"GET",
 		"/server/stop",
 		StopServer,
-        CheckAuth,
 	}, {
 		"RunningServer",
 		"GET",
 		"/server/status",
 		CheckServer,
-        CheckAuth,
-	}, {
-		"LoginUser",
-		"POST",
-		"/login",
-		LoginUser,
-        nil,
 	}, {
 		"LogoutUser",
 		"GET",
 		"/logout",
 		LogoutUser,
-        CheckAuth,
 	}, {
 		"StatusUser",
 		"GET",
 		"/user/status",
 		GetCurrentLogin,
-        CheckAuth,
 	}, {
 		"ListUsers",
 		"GET",
 		"/user/list",
 		ListUsers,
-        CheckAuth,
 	}, {
 		"AddUser",
 		"POST",
 		"/user/add",
 		AddUser,
-        CheckAuth,
 	}, {
 		"RemoveUser",
 		"POST",
 		"/user/remove",
 		RemoveUser,
-        CheckAuth,
 	}, {
 		"ListModPacks",
 		"GET",
 		"/mods/packs/list",
 		ListModPacks,
-        CheckAuth,
 	}, {
 		"DownloadModPack",
 		"GET",
 		"/mods/packs/dl/{modpack}",
 		DownloadModPack,
-        CheckAuth,
 	}, {
 		"DeleteModPack",
 		"GET",
 		"/mods/packs/rm/{modpack}",
 		DeleteModPack,
-        CheckAuth,
 	}, {
 		"CreateModPack",
 		"POST",
 		"/mods/packs/add",
 		CreateModPackHandler,
-        CheckAuth,
 	},
 }

--- a/ui/App/components/LoginContent.jsx
+++ b/ui/App/components/LoginContent.jsx
@@ -20,7 +20,7 @@ class LoginContent extends React.Component {
 
         $.ajax({
             type: "POST",
-            url: "/login",
+            url: "/api/login",
             dataType: "json",
             data: JSON.stringify(user),
             success: (resp) => {


### PR DESCRIPTION
Right, so it turns out having nginx serve /login as a static file and then post to the same location is rather complex. At least, I couldn't find a clear way to route a GET to a static location and then a POST to the proxy.

So, I figured an easier solution would be to move the login POST to the api router (/api/login).