### PR TITLE
Fix nil pointer in saves

### DIFF
--- a/src/saves.go
+++ b/src/saves.go
@@ -22,6 +22,7 @@ func (s Save) String() string {
 
 // Lists save files in factorio/saves
 func listSaves(saveDir string) (saves []Save, err error) {
+	saves = []Save{}
 	err = filepath.Walk(saveDir, func(path string, info os.FileInfo, err error) error {
 		if info.IsDir() && info.Name() == "saves" {
 			return nil


### PR DESCRIPTION
If there were no saves, listSaves would return a nil slice.