### PR TITLE
Make FactorioServer.Settings use a map instead of a struct

### DIFF
--- a/src/handlers.go
+++ b/src/handlers.go
@@ -993,7 +993,10 @@ func UpdateServerSettings(w http.ResponseWriter, r *http.Request) {
 			log.Printf("Failed to marshal server settings: %s", err)
 			return
 		} else {
-			ioutil.WriteFile(filepath.Join(config.FactorioDir, "server-settings.json"), settings, 0644)
+			if err = ioutil.WriteFile(filepath.Join(config.FactorioConfigDir, config.SettingsFile), settings, 0644); err != nil {
+				log.Printf("Failed to save server settings: %v\n", err)
+				return
+			}
 			log.Printf("Saved Factorio server settings in server-settings.json")
 		}
 

--- a/src/main.go
+++ b/src/main.go
@@ -88,8 +88,14 @@ func main() {
 	parseFlags()
 	loadServerConfig(config.ConfFile)
 
+	var err error
+
 	// Initialize Factorio Server struct
-	FactorioServ = initFactorio()
+	FactorioServ, err = initFactorio()
+	if err != nil {
+		log.Printf("Error occurred during FactorioServer initializaion: %v\n", err)
+		return
+	}
 
 	// Initialize authentication system
 	Auth = initAuth()

--- a/ui/App/components/ConfigContent.jsx
+++ b/ui/App/components/ConfigContent.jsx
@@ -77,6 +77,17 @@ class ConfigContent extends React.Component {
     }
 
     formTypeField(key, setting) {
+        if (key.startsWith("_comment_")) {
+            return (
+                <input 
+                   key={key}
+                   ref={key}
+                   id={key}
+                   defaultValue={setting}
+                   type="hidden"
+                />
+            )
+        }
         if (typeof setting === "number") {
             return (
                 <input
@@ -163,13 +174,17 @@ class ConfigContent extends React.Component {
                                     <div className="table-responsive">
                                         <form ref="settingsForm" className="form-horizontal" onSubmit={this.updateServerSettings}>
                                             {Object.keys(this.state.serverSettings).map(function(key) {
+                                                if (key.startsWith("_comment_"))
+                                                    return(<div>{this.formTypeField(key, setting)}</div>);
                                                 var setting = this.state.serverSettings[key]
                                                 var setting_key = key.replace(/_/g, " ")
+                                                var comment = this.state.serverSettings["_comment_" + key]
                                                 return(
                                                 <div className="form-group">
                                                     <label for={key} className="control-label col-md-3">{setting_key}</label>
                                                     <div className="col-md-6">
                                                         {this.formTypeField(key, setting)}
+                                                        <p className="help-block">{comment}</p>
                                                     </div>
                                                 </div>
                                                 )
@@ -198,7 +213,7 @@ class ConfigContent extends React.Component {
                         <div className="row">
                             <div className="col-md-10">
                             {Object.keys(this.state.config).map(function(key) {
-                                var conf = this.state.config[key]
+				var conf = this.state.config[key]
                                 return(
                                     <div className="settings-section" key={key}>
                                     <h3>{key}</h3>


### PR DESCRIPTION
To prevent future Factorio updates breaking the server settings,
use a map to store settings. Also, comments are now preserved and
used as help text in the UI. Note: they are also passed through
the settings form, but hidden. Also improved: error handling/logging in
FactorioServer init and more error checking in the handler.